### PR TITLE
Added Apple Silicon definitions to enable gnatprove build on M1

### DIFF
--- a/src/common/aarch64-darwin/platform.adb
+++ b/src/common/aarch64-darwin/platform.adb
@@ -4,7 +4,7 @@
 --                                                                          --
 --                              P L A T F O R M                             --
 --                                                                          --
---                                 S p e c                                  --
+--                                 B o d y                                  --
 --                                                                          --
 --                     Copyright (C) 2010-2022, AdaCore                     --
 --                                                                          --
@@ -23,15 +23,15 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-package Platform is
+package body Platform is
 
-   --  Value CodePeer_OS for the host OS flavor is for analysis of GNATprove
-   --  code by CodePeer.
+   -------------------
+   -- Get_OS_Flavor --
+   -------------------
 
-   type Host_Operating_System_Flavor is
-      (X86_Windows, X86_64_Windows, X86_Linux, X86_64_Linux, X86_64_Darwin,
-       X86_64_FreeBSD, CodePeer_OS, AArch64_Darwin);
-
-   function Get_OS_Flavor return Host_Operating_System_Flavor;
+   function Get_OS_Flavor return Host_Operating_System_Flavor is
+   begin
+      return AArch64_Darwin;
+   end Get_OS_Flavor;
 
 end Platform;

--- a/src/gnatprove/spark_report.adb
+++ b/src/gnatprove/spark_report.adb
@@ -1039,7 +1039,8 @@ procedure SPARK_Report is
              when X86_Linux   | X86_64_Linux   => "Linux",
              when X86_64_Darwin                => "Darwin",
              when X86_64_FreeBSD               => "FreeBSD",
-             when CodePeer_OS                  => "CodePeer OS");
+             when CodePeer_OS                  => "CodePeer OS",
+             when AArch64_Darwin               => "Darwin");
 
       Pointer_Size : constant :=
         System.Storage_Elements.Integer_Address'Size / System.Storage_Unit;


### PR DESCRIPTION
These changes enabled me to build gnatprove and the associated binaries (gnat2why etc) on Apple Silicon using the native AARCH64 FSF GNAT build obtained here: https://github.com/simonjwright/distributing-gcc/releases/tag/aarch64-apple-darwin21-2.

Using the tool I was able to run gnatprove on a project successfully using the z3 prover.