### PR TITLE
[PATCH] Makefile: use `$(INSTALLDIR)` rather than `install/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ why3:
 install-all:
 	$(MAKE) install
 	$(MAKE) -C why3 install_spark2014_dev
-	sha256sum install/libexec/spark/bin/gnatwhy3 | cut -d' ' -f1 > install/libexec/spark/bin/gnatwhy3.hash
+	sha256sum $(INSTALLDIR)/libexec/spark/bin/gnatwhy3 | cut -d' ' -f1 > $(INSTALLDIR)/libexec/spark/bin/gnatwhy3.hash
 	# Create the fake prover scripts to help extract benchmarks.
-	$(CP) benchmark_script/fake_* install/libexec/spark/bin
+	$(CP) benchmark_script/fake_* $(INSTALLDIR)/libexec/spark/bin
 
 install:
 	mkdir -p $(INSTALLDIR)/bin $(CONFIGDIR) $(THEORIESDIR) \


### PR DESCRIPTION
This is a minor bugfix to make the installation procedure use the set `$(INSTALLDIR)` target directory.